### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/weisuke/gulp-module-requirejs/issues"
   },
-  "homepage": "https://github.com/weisuke/gulp-module-requirejs"
+  "homepage": "https://github.com/weisuke/gulp-module-requirejs",
+  "keywords": [
+    "gulpplugin"  
+  ]
 }


### PR DESCRIPTION
Adding keyword so module shows up on http://gulpjs.com/plugins/
